### PR TITLE
Minor post-adoption changes 

### DIFF
--- a/v6ops-ietf-icmpext-xlat-v6only-source.xml
+++ b/v6ops-ietf-icmpext-xlat-v6only-source.xml
@@ -227,11 +227,21 @@ Such implementations SHOULD still translate ICMPv6 Packet Too Big from untransla
 <t>
 <xref target="RFC6791"/> proposes using the Interface Information Object and Interface IP Address Sub-Object defined in <xref target="RFC5837"/> to preserve the information about untranslatable IPv6 addresses.
 However it should be noted that Section 4.2 of <xref target="RFC5837"/> suggests that an IPv4 packet MUST only contain an IP Interface Sub-Object representint an IPv4 address.
+Therefore using the mechanism described in <xref target="RFC6791"/> requires updating  <xref target="RFC5837"/>.
+</t>
+<t>
+More importantly, section 3.2 of <xref target="RFC6791"/> recommends using a single (or small pool of) public IPv4 address as the source address of the translated ICMP message.
+Such approach assumes that the translator is configured with an least one public IPv4 address, which is often not feasible for CLAT instances running on endpoints like mobile phones, laptops etc.
 </t>
 <t>
 The solution proposes in this document has a number of benefits:
 </t>
 <ul>
+<li>
+<t>
+Does not require public IPv4 addresses configured on the translator.
+</t>
+</li>
 <li>
 <t>
 No changes to processing of the Interface Information Object is required.
@@ -243,6 +253,7 @@ Using a dedicated IPV4 dummy address 192.0.0.8 might be benefitial to indicate t
 </t>
 </li>
 </ul>
+
 
 <t>
 Therefore this document deprecates <xref target="RFC6791"/>.
@@ -429,7 +440,7 @@ If the resulting packet size exceeds the minimum IPv6 MTU: truncate the embedded
       <name>Acknowledgements</name>
       <t>
           This document is the result of discussions with Thomas Jensen.
-          The authors would like to thank Lorenzo Colitti, Darren Dukes, Bill Fenner, Tobias Fiebig for their feedback, comments and guidance.
+          The authors would like to thank Ondrej Caletka, Lorenzo Colitti, Darren Dukes, Bill Fenner, Tobias Fiebig for their feedback, comments and guidance.
 The authors would like to particularly thank Tore Anderson for pointing out the existence and relevance of <xref target="RFC6791"/>.
 
       </t>

--- a/v6ops-ietf-icmpext-xlat-v6only-source.xml
+++ b/v6ops-ietf-icmpext-xlat-v6only-source.xml
@@ -101,10 +101,10 @@ Received ICMPv6 Time Exceeded are translated to ICMP Time Exceeded. If those pac
 Those packets are usually dropped and tools like traceroute can not represent IPv6 intermediate hops in any meaningful way. Such behaviour complicates troubleshooting. It's also confusing for users and increases operational costs, as users report packet loss in the network based on traceroute output.
 </t>
       <t>
-Some CLAT implementations are known to workaround this issue by representing IPv6 addresses in IPv4 traceroute by using a reserved IPv4 address space and using the hop limit as the last octet, so an IPv6 device 5 hops away is shown as 225.0.0.5 etc.
+Some CLAT implementations are known to workaround this issue by representing IPv6 addresses in IPv4 traceroute by using a reserved IPv4 address space and using the hop limit as the last octet, so an IPv6 address from 5 hops away is shown as 225.0.0.5 etc.
       </t>
 <t>
-It should be noted that the similar issue occurs in IPv6 Data Center Environments when an ICMPv6 error message needs to be sent to an IPv4-only client.
+It should be noted that the similar issue occurs in IPv6 Data Center Environments when an ICMPv6 error message is sent to an IPv4-only client.
 As per Section 4.8 of <xref target="RFC7755"/>, ICMPv6 error packets are usually dropped by the translator.
 </t>
 <t>
@@ -195,17 +195,12 @@ This document doesn't prescribe the exact algorith for adding the Node Identific
 <ul>
 <li>
 <t>
-The resulting ICMPv6 message contains the Node Identification Extension Object with the IP Address Sub-Object.
+The resulting ICMPv4 message contains the Node Identification Extension Object with the IP Address Sub-Object.
 </t>
 </li>
 <li>
 <t>
 The checksum field of the Extension Header (Section 7 of <xref target="RFC4884"/>) is updated accordingly.
-</t>
-</li>
-<li>
-<t>
-The resulting ICMPv6 packet size doesn't exceed the minimum IPv6 MTU.
 </t>
 </li>
 </ul>


### PR DESCRIPTION
* Fixing ICMPv4/ICMPv6 mixup (thanks Ondrej!)
* Adding one more reason why RFC6791 can't be used (it suggests to use public IPv4 as a source...)
* Minor text tweaks